### PR TITLE
Use pkg-config flags correctly

### DIFF
--- a/inc/CheckForLibPng.pm
+++ b/inc/CheckForLibPng.pm
@@ -127,11 +127,11 @@ sub check_for_libpng
 	$pkg_config_ldflags =~ s/\s+$//;
 	if ($pkg_config_cflags) {
 	    msg ("Adding '$pkg_config_cflags' to C compiler flags from pkg-config");
-	    $inc = "$inc $pkg_config_cflags";
+	    $inc = "$pkg_config_cflags";
 	}
 	if ($pkg_config_ldflags) {
 	    msg ("Adding '$pkg_config_ldflags' to linker flags from pkg-config");
-	    $libs = "$pkg_config_ldflags $libs";
+	    $libs = "$pkg_config_ldflags";
 	}
     }
 

--- a/tmpl/Makefile.PL.tmpl
+++ b/tmpl/Makefile.PL.tmpl
@@ -43,8 +43,8 @@ if ($vars) {
     if ($vars->{inc}) {
 	$wm{INC} = "$vars->{inc}";
     }
-    if ($vars->{lib}) {
-	$wm{LIBS} = "$vars->{lib} $wm{LIBS}";
+    if ($vars->{libs}) {
+	$wm{LIBS} = "$vars->{libs}";
     }
 }
 


### PR DESCRIPTION
This patch fixes two issues:

Linker flags were ignored because of a typo in Makefile.PL.
Flags obtained by pkg-config were contaminated by default flag values.