### PR TITLE
Do not contaminate pkg-config flags

### DIFF
--- a/inc/CheckForLibPng.pm
+++ b/inc/CheckForLibPng.pm
@@ -143,12 +143,12 @@ sub check_for_libpng
 	    my $pkg_config_ldflags = `pkg-config --libs libpng`;
 	    $pkg_config_ldflags =~ s/\s+$//;
 	    if ($pkg_config_cflags) {
-		msg ("Adding '$pkg_config_cflags' to C compiler flags from pkg-config");
-		$inc = "$inc $pkg_config_cflags";
+		msg ("Replacing C compiler flags with '$pkg_config_cflags' from pkg-config");
+		$inc = "$pkg_config_cflags";
 	    }
 	    if ($pkg_config_ldflags) {
-		msg ("Adding '$pkg_config_ldflags' to linker flags from pkg-config");
-		$libs = "$pkg_config_ldflags $libs";
+		msg ("Replacing linker flags with '$pkg_config_ldflags' from pkg-config");
+		$libs = "$pkg_config_ldflags";
 	    }
 	}
     }


### PR DESCRIPTION
Flags from pkg-config were contaminates with manual '-lpng -lz -lm' flags. As a result you passed both of them to a linker

    gcc  -lpng16 -lz -lpng -lz -lm...

This was a regression against
<https://github.com/benkasminbullock/image-png-libpng/pull/30> caused
by 544f18ce464c5fed832abed09ceef05417a27a3d commit.

This patch fixes it.