### PR TITLE
Remove size tests from t/compress-level.t

### DIFF
--- a/t/compress-level.t
+++ b/t/compress-level.t
@@ -23,45 +23,6 @@ skip_old ();
 
 use Image::PNG::Libpng ':all';
 
-# These are the compression levels used in the PngSuite 
-
-my @levels = (0, 3, 6, 9);
-
-my $filesizes_changed = 0;
-
-# Read the example files
-
-foreach my $src_level (@levels) {
-    my $ffile = sprintf("%s/libpng/z%02dn2c08.png", $Bin, $src_level);
-    my $src_size = -s $ffile;
-    my $src_png = read_png_file ($ffile);
-    ok ($src_png, "Read test file '$ffile'");
-
-    foreach my $target_level (@levels) {
-	my $dest_png = copy_png ($src_png);
-	$dest_png->set_compression_level ($target_level);
-	my $output = $dest_png->write_to_scalar ();
-	my $dest_size = length $output;
-	if ($src_level == $target_level) {
-	    cmp_ok ($src_size, '==', $dest_size,
-		"source $ffile (level: $src_level, $src_size bytes) equal to target (level: $target_level, $dest_size bytes)" );
-	}
-	elsif ($src_level < $target_level) {
-	    cmp_ok ($src_size, '>=', $dest_size,
-		"source $ffile (level: $src_level, $src_size bytes) larger than target (level: $target_level, $dest_size bytes)" );
-	    $filesizes_changed++;
-	}
-	else {
-	    cmp_ok ($src_size, '<=', $dest_size,
-		"source $ffile (level: $src_level, $src_size bytes) smaller than target (level: $target_level, $dest_size bytes)" );
-	    $filesizes_changed++;
-	}
-    }
-}
-
-ok ($filesizes_changed > 0,
-    "$filesizes_changed files changed size because of compress_level");
-
 # Test failures
 
 my $ffile = "$Bin/libpng/z06n2c08.png";


### PR DESCRIPTION
t/compress-level.t exhibits various compression levels and checks that the recompressed image has same size as the prebuilt image. However, that assumes exactly the same compression algorithm is used for both of them. And indeed the sizes start to differ among zlib and zlib-ng:

    ok 6 - Read test file '/home/test/fedora/perl-Image-PNG-Libpng/Image-PNG-Libpng-0.57/t/libpng/z03n2c08.png'
    ok 7 - source /home/test/fedora/perl-Image-PNG-Libpng/Image-PNG-Libpng-0.57/t/libpng/z03n2c08.png (level: 3, 232 bytes) smaller than target (level: 0, 3172 bytes)
    not ok 8 - source /home/test/fedora/perl-Image-PNG-Libpng/Image-PNG-Libpng-0.57/t/libpng/z03n2c08.png (level: 3, 232 bytes) equal to target (level: 3, 231 bytes)
    #   Failed test 'source /home/test/fedora/perl-Image-PNG-Libpng/Image-PNG-Libpng-0.57/t/libpng/z03n2c08.png (level: 3, 232 bytes) equal to target (level: 3, 231 bytes)'
    #   at t/compress-level.t line 46.
    #          got: 232
    #     expected: 231
    ok 9 - source /home/test/fedora/perl-Image-PNG-Libpng/Image-PNG-Libpng-0.57/t/libpng/z03n2c08.png (level: 3, 232 bytes) larger than target (level: 6, 224 bytes)
    ok 10 - source /home/test/fedora/perl-Image-PNG-Libpng/Image-PNG-Libpng-0.57/t/libpng/z03n2c08.png (level: 3, 232 bytes) larger than target (level: 9, 224 bytes)

This patch simply removes the concerned test.

Fixes: #40